### PR TITLE
chore(deps): apply pending Renovate updates

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Load cache
         uses: actions/cache@v4
         with:
@@ -57,7 +57,7 @@ jobs:
       - name: Ensure line endings are consistent
         run: git config --global core.autocrlf input
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
@@ -102,7 +102,7 @@ jobs:
         with:
           node-version: '26.x'
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Load cache
         uses: actions/cache@v4
         with:
@@ -125,7 +125,7 @@ jobs:
         with:
           node-version: '26.x'
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
       - name: Load cache
         uses: actions/cache@v4
         with:

--- a/package.json
+++ b/package.json
@@ -93,7 +93,7 @@
     "@types/n3": "1.26.1",
     "componentsjs": "6.2.0",
     "rdf-data-factory": "^2.0.0",
-    "shaclc-parse": "1.4.3",
+    "shaclc-parse": "2.0.0",
     "sparqlalgebrajs": "^5.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@rubensworks/eslint-config": "^3.0.0",
     "@types/jest": "^29.0.0",
     "@types/md5": "^2.3.5",
-    "@types/node": "^22.13.1",
+    "@types/node": "^24.0.0",
     "@types/readable-stream": "4.0.20",
     "@types/ws": "^8.5.10",
     "arrayify-stream": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "typedoc": "^0.28.0",
     "typescript": "^5.0.0",
     "webpack": "^5.88.2",
-    "webpack-cli": "^6.0.0",
+    "webpack-cli": "^7.0.0",
     "ws": "^8.18.0"
   },
   "resolutions": {

--- a/packages/actor-bindings-aggregator-factory-max/lib/MaxAggregator.ts
+++ b/packages/actor-bindings-aggregator-factory-max/lib/MaxAggregator.ts
@@ -3,7 +3,7 @@ import type { IExpressionEvaluator } from '@comunica/types';
 import type { IBindingsAggregator } from '@incremunica/bus-bindings-aggregator-factory';
 import { AggregateEvaluator } from '@incremunica/bus-bindings-aggregator-factory';
 import type * as RDF from '@rdfjs/types';
-import AVLTree from 'avl';
+import { AVLTree } from 'avl';
 import type { Term } from 'n3';
 import { termToString } from 'rdf-string';
 

--- a/packages/actor-bindings-aggregator-factory-max/package.json
+++ b/packages/actor-bindings-aggregator-factory-max/package.json
@@ -43,7 +43,7 @@
     "@incremunica/bus-bindings-aggregator-factory": "^2.3.2",
     "@rdfjs/types": "*",
     "avl": "^2.0.0",
-    "n3": "^1.23.0",
+    "n3": "^2.0.0",
     "rdf-string": "^2.0.1"
   }
 }

--- a/packages/actor-bindings-aggregator-factory-max/package.json
+++ b/packages/actor-bindings-aggregator-factory-max/package.json
@@ -42,7 +42,7 @@
     "@comunica/types": "^4.2.0",
     "@incremunica/bus-bindings-aggregator-factory": "^2.3.2",
     "@rdfjs/types": "*",
-    "avl": "^1.5.3",
+    "avl": "^2.0.0",
     "n3": "^1.23.0",
     "rdf-string": "^2.0.1"
   }

--- a/packages/actor-bindings-aggregator-factory-min/lib/MinAggregator.ts
+++ b/packages/actor-bindings-aggregator-factory-min/lib/MinAggregator.ts
@@ -3,7 +3,7 @@ import type { IExpressionEvaluator } from '@comunica/types';
 import type { IBindingsAggregator } from '@incremunica/bus-bindings-aggregator-factory';
 import { AggregateEvaluator } from '@incremunica/bus-bindings-aggregator-factory';
 import type * as RDF from '@rdfjs/types';
-import AVLTree from 'avl';
+import { AVLTree } from 'avl';
 import type { Term } from 'n3';
 import { termToString } from 'rdf-string';
 

--- a/packages/actor-bindings-aggregator-factory-min/package.json
+++ b/packages/actor-bindings-aggregator-factory-min/package.json
@@ -43,7 +43,7 @@
     "@incremunica/bus-bindings-aggregator-factory": "^2.3.2",
     "@rdfjs/types": "*",
     "avl": "^2.0.0",
-    "n3": "^1.23.0",
+    "n3": "^2.0.0",
     "rdf-string": "^2.0.1"
   }
 }

--- a/packages/actor-bindings-aggregator-factory-min/package.json
+++ b/packages/actor-bindings-aggregator-factory-min/package.json
@@ -42,7 +42,7 @@
     "@comunica/types": "^4.2.0",
     "@incremunica/bus-bindings-aggregator-factory": "^2.3.2",
     "@rdfjs/types": "*",
-    "avl": "^1.5.3",
+    "avl": "^2.0.0",
     "n3": "^1.23.0",
     "rdf-string": "^2.0.1"
   }

--- a/packages/actor-query-source-identify-streaming-rdfjs/test/StreamingQuerySourceRdfJs-test.ts
+++ b/packages/actor-query-source-identify-streaming-rdfjs/test/StreamingQuerySourceRdfJs-test.ts
@@ -370,16 +370,18 @@ describe('StreamingQuerySourceRdfJs', () => {
         AF.createPattern(DF.variable('s'), DF.namedNode('p'), DF.variable('o'), DF.variable('g')),
         ctx,
       );
+      // N3.js 2 assigns the default graph the lowest internal identifier, so it is
+      // iterated before any named graph.
       await expect(data).toEqualBindingsStream([
-        BF.fromRecord({
-          s: DF.namedNode('s1'),
-          o: DF.namedNode('o1'),
-          g: DF.namedNode('g1'),
-        }).setContextEntry(KeysBindings.isAddition, true),
         BF.fromRecord({
           s: DF.namedNode('s2'),
           o: DF.namedNode('o2'),
           g: DF.defaultGraph(),
+        }).setContextEntry(KeysBindings.isAddition, true),
+        BF.fromRecord({
+          s: DF.namedNode('s1'),
+          o: DF.namedNode('o1'),
+          g: DF.namedNode('g1'),
         }).setContextEntry(KeysBindings.isAddition, true),
       ]);
       //

--- a/packages/streaming-store/package.json
+++ b/packages/streaming-store/package.json
@@ -41,7 +41,7 @@
     "@rdfjs/types": "*",
     "@types/n3": "*",
     "@types/readable-stream": "4.0.20",
-    "n3": "^1.16.3",
+    "n3": "^2.0.0",
     "rdf-string": "^2.0.1",
     "rdf-terms": "^2.0.0",
     "readable-stream": "^4.3.0"

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,7 +37,7 @@
     "@comunica/types": "^4.2.0",
     "@rdfjs/types": "*",
     "asynciterator": "^3.9.0",
-    "n3": "^1.16.3",
+    "n3": "^2.0.0",
     "readable-stream": "^4.7.0"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "target": "es2021",
     "lib": [
-      "es2021",
+      "es2022",
       "dom"
     ],
     "module": "commonjs",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5582,10 +5582,10 @@ available-typed-arrays@^1.0.7:
   dependencies:
     possible-typed-array-names "^1.0.0"
 
-avl@^1.5.3:
-  version "1.5.3"
-  resolved "https://registry.yarnpkg.com/avl/-/avl-1.5.3.tgz#c1fedf023926fa598f23c9d65481b375af6c328a"
-  integrity sha512-1qcOJeREIosJxIBof2nefabU9+Y3wCxXBb3ElQmNVOHP+Hu2BLWAh8CpU7xFnJNDMVBt2H5UOE2S/B7MEqhTsg==
+avl@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/avl/-/avl-2.0.0.tgz#9e59284b9e6a995edd90a9258f950a0e5e6c0aac"
+  integrity sha512-imPAgmVrjf2kRru+U9brsmAfVYVbIGPTqGFSouYfPEJZSv2FvitwGb1HjqANuAPtnabWoteHv4xEWkKIPB10mA==
 
 axios@1.18.1:
   version "1.18.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11355,15 +11355,6 @@ n3@^1.16.3, n3@^1.17.0, n3@^1.17.1:
     queue-microtask "^1.1.2"
     readable-stream "^4.0.0"
 
-n3@^1.23.0:
-  version "1.23.0"
-  resolved "https://registry.yarnpkg.com/n3/-/n3-1.23.0.tgz#463d6da406ae03d2534d3404dae777c7773483f8"
-  integrity sha512-JEbhFlxFTNsHTHUAGykRoVNRG4Sqsu8Wn+SXq99l9pRQPgqJzvY4CwNp/yxRGwb4oni9BT5sH5kevnbVUIUvkQ==
-  dependencies:
-    buffer "^6.0.3"
-    queue-microtask "^1.1.2"
-    readable-stream "^4.0.0"
-
 n3@^1.26.0:
   version "1.26.0"
   resolved "https://registry.yarnpkg.com/n3/-/n3-1.26.0.tgz#3d69de04bee680b9ebec9dbc1033dc1e6934d351"

--- a/yarn.lock
+++ b/yarn.lock
@@ -11372,6 +11372,14 @@ n3@^1.26.0:
     buffer "^6.0.3"
     readable-stream "^4.0.0"
 
+n3@^2.0.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/n3/-/n3-2.4.0.tgz#475aca70afb1343a1929be603cbf4cf94783a954"
+  integrity sha512-rQgwsKqGacptMSFnwRPJxTkfBcuRPd/opAc8V4uLn3/EAFz2nXQdfP2xFlQI38pzFZ/QMggxMQ60HaEVxmeLdg==
+  dependencies:
+    buffer "^6.0.3"
+    readable-stream "^4.0.0"
+
 nanoid@^3.3.6:
   version "3.3.7"
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
@@ -13501,13 +13509,13 @@ sha.js@^2.4.0, sha.js@^2.4.8:
     inherits "^2.0.1"
     safe-buffer "^5.0.1"
 
-shaclc-parse@1.4.3, shaclc-parse@^1.4.0:
-  version "1.4.3"
-  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-1.4.3.tgz#56de4d03408f0768bf66c70d655cff33ccae410d"
-  integrity sha512-MQJWVFjfzzMUvieFO0STWjIo49ywy63UkVSsr0e8+8xHUns6X+i3yWYxNKd+GtSEJjBNZxxrUubog+hnd7PvRA==
+shaclc-parse@2.0.0, shaclc-parse@^1.4.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/shaclc-parse/-/shaclc-parse-2.0.0.tgz#326fa50202bb5bc104c9bd10e55a9016f21431e9"
+  integrity sha512-YEznPru7QmcIR1lF/lCvvrrcjZ8vWfKBMAketPb2CRWkrA0LUffTzrW0tOepue/evUREkJyl8LeVpcmyyKF+ng==
   dependencies:
     "@rdfjs/types" "^2.0.0"
-    n3 "^1.16.3"
+    n3 "^2.0.0"
 
 shaclc-write@^1.4.2:
   version "1.4.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4654,12 +4654,12 @@
   dependencies:
     undici-types "~5.26.4"
 
-"@types/node@^22.13.1":
-  version "22.13.1"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.13.1.tgz#a2a3fefbdeb7ba6b89f40371842162fac0934f33"
-  integrity sha512-jK8uzQlrvXqEU91UxiK5J7pKHyzgnI1Qnl0QDHIgVGuolJhRb9EEl28Cj9b3rGR8B2lhFCtvIm5os8lFnO/1Ew==
+"@types/node@^24.0.0":
+  version "24.13.3"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-24.13.3.tgz#49f18bd3c647866dcda51a0756c145e14590ce16"
+  integrity sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==
   dependencies:
-    undici-types "~6.20.0"
+    undici-types "~7.18.0"
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.4"
@@ -14710,10 +14710,10 @@ undici-types@~5.26.4:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
   integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
 
-undici-types@~6.20.0:
-  version "6.20.0"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.20.0.tgz#8171bf22c1f588d1554d55bf204bc624af388433"
-  integrity sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==
+undici-types@~7.18.0:
+  version "7.18.2"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.18.2.tgz#29357a89e7b7ca4aef3bf0fd3fd0cd73884229e9"
+  integrity sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==
 
 undici@^6.25.0:
   version "6.28.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3025,10 +3025,10 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@discoveryjs/json-ext@^0.6.1":
-  version "0.6.3"
-  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz#f13c7c205915eb91ae54c557f5e92bddd8be0e83"
-  integrity sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==
+"@discoveryjs/json-ext@^1.1.0":
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/@discoveryjs/json-ext/-/json-ext-1.1.0.tgz#44b5ce3485e95235aca06e628eeaaa3c816bc4cc"
+  integrity sha512-Xc3VhU02wqZ1HvHRJUwL09HkZSTvidqY5Ya0NXBSYOxAp+Ln9dcJr9fySI+CkONzP3PekQo9WdzCv0PGER/mOA==
 
 "@emnapi/core@1.4.5":
   version "1.4.5"
@@ -5132,21 +5132,6 @@
     "@webassemblyjs/ast" "1.12.1"
     "@xtuc/long" "4.2.2"
 
-"@webpack-cli/configtest@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/configtest/-/configtest-3.0.1.tgz#76ac285b9658fa642ce238c276264589aa2b6b57"
-  integrity sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==
-
-"@webpack-cli/info@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/info/-/info-3.0.1.tgz#3cff37fabb7d4ecaab6a8a4757d3826cf5888c63"
-  integrity sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==
-
-"@webpack-cli/serve@^3.0.1":
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/@webpack-cli/serve/-/serve-3.0.1.tgz#bd8b1f824d57e30faa19eb78e4c0951056f72f00"
-  integrity sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==
-
 "@xtuc/ieee754@^1.2.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@xtuc/ieee754/-/ieee754-1.2.0.tgz#eef014a3145ae477a1cbc00cd1e552336dceb790"
@@ -6370,11 +6355,6 @@ color@^3.1.3:
     color-convert "^1.9.3"
     color-string "^1.6.0"
 
-colorette@^2.0.14:
-  version "2.0.20"
-  resolved "https://registry.yarnpkg.com/colorette/-/colorette-2.0.20.tgz#9eb793e6833067f7235902fcd3b09917a000a95a"
-  integrity sha512-IfEDxwoWIjkeXL1eXcDiow4UbKjhLdq6/EuSVR9GMN7KVH3r9gQ83e73hsz1Nd1T3ijd5xv1wcWRYO+D6kCI2w==
-
 colorspace@1.1.x:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/colorspace/-/colorspace-1.1.4.tgz#8d442d1186152f60453bf8070cd66eb364e59243"
@@ -6398,10 +6378,10 @@ combined-stream@1.0.8, combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
-commander@^12.1.0:
-  version "12.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-12.1.0.tgz#01423b36f501259fdaac4d0e4d60c96c991585d3"
-  integrity sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==
+commander@^14.0.3:
+  version "14.0.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-14.0.3.tgz#425d79b48f9af82fcd9e4fc1ea8af6c5ec07bbc2"
+  integrity sha512-H+y0Jo/T1RZ9qPP4Eh1pkcQcLRglraJaSLoyOtHxu6AapkjWVCy2Sit1QQ4x3Dng8qDlSsZEet7g5Pq06MvTgw==
 
 commander@^2.20.0:
   version "2.20.3"
@@ -7321,10 +7301,10 @@ envinfo@7.13.0:
   resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.13.0.tgz#81fbb81e5da35d74e814941aeab7c325a606fb31"
   integrity sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==
 
-envinfo@^7.14.0:
-  version "7.14.0"
-  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.14.0.tgz#26dac5db54418f2a4c1159153a0b2ae980838aae"
-  integrity sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==
+envinfo@^7.21.0:
+  version "7.21.0"
+  resolved "https://registry.yarnpkg.com/envinfo/-/envinfo-7.21.0.tgz#04a251be79f92548541f37d13c8b6f22940c3bae"
+  integrity sha512-Lw7I8Zp5YKHFCXL7+Dz95g4CcbMEpgvqZNNq3AmlT5XAV6CgAAk6gyAMqn2zjw08K9BHfcNuKrMiCPLByGafow==
 
 err-code@^2.0.2:
   version "2.0.3"
@@ -8218,11 +8198,6 @@ fast-levenshtein@^2.0.6:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
-
-fastest-levenshtein@^1.0.12:
-  version "1.0.16"
-  resolved "https://registry.yarnpkg.com/fastest-levenshtein/-/fastest-levenshtein-1.0.16.tgz#210e61b6ff181de91ea9b3d1b84fdedd47e034e5"
-  integrity sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==
 
 fastq@^1.6.0:
   version "1.15.0"
@@ -9203,6 +9178,14 @@ import-local@3.1.0, import-local@^3.0.2:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.1.0.tgz#b4479df8a5fd44f6cdce24070675676063c95cb4"
   integrity sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==
+  dependencies:
+    pkg-dir "^4.2.0"
+    resolve-cwd "^3.0.0"
+
+import-local@^3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/import-local/-/import-local-3.2.0.tgz#c3d5c745798c02a6f8b897726aba5100186ee260"
+  integrity sha512-2SPlun1JUPWoM6t3F0dw0FkCF/jWY8kttcY4f599GLTSjh2OCuuhdTkJQsEcZzBqbXZGKMK2OqW1oZsjtf/gQA==
   dependencies:
     pkg-dir "^4.2.0"
     resolve-cwd "^3.0.0"
@@ -14956,21 +14939,16 @@ webidl-conversions@^3.0.0:
   resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
   integrity sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==
 
-webpack-cli@^6.0.0:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-6.0.1.tgz#a1ce25da5ba077151afd73adfa12e208e5089207"
-  integrity sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==
+webpack-cli@^7.0.0:
+  version "7.2.2"
+  resolved "https://registry.yarnpkg.com/webpack-cli/-/webpack-cli-7.2.2.tgz#94ff4f8a28aa087c8127c821e26a6fd0a50323e5"
+  integrity sha512-lD0pALneslq8FfV+rwvm1BMW0AFAJrHHhNupAGN4asYjMvqrtRsenU4iKpiBo09gS4ntMxKGUxl9jhTEzVt0oA==
   dependencies:
-    "@discoveryjs/json-ext" "^0.6.1"
-    "@webpack-cli/configtest" "^3.0.1"
-    "@webpack-cli/info" "^3.0.1"
-    "@webpack-cli/serve" "^3.0.1"
-    colorette "^2.0.14"
-    commander "^12.1.0"
-    cross-spawn "^7.0.3"
-    envinfo "^7.14.0"
-    fastest-levenshtein "^1.0.12"
-    import-local "^3.0.2"
+    "@discoveryjs/json-ext" "^1.1.0"
+    commander "^14.0.3"
+    cross-spawn "^7.0.6"
+    envinfo "^7.21.0"
+    import-local "^3.2.0"
     interpret "^3.1.1"
     rechoir "^0.8.0"
     webpack-merge "^6.0.1"


### PR DESCRIPTION
Works through the pending Renovate updates one commit at a time. Each commit was validated independently with `yarn install` (which runs the full build + components generation), `yarn lint-no-cache`, and `yarn test` — including the 100% coverage thresholds. Updates that could not be made to pass were left out and are listed below with the reason.

Base branch is `next/minor`, matching Renovate's configured base.

## Applied

| Update | Notes |
| --- | --- |
| `@types/node` → v24 (#161) | v24 dropped its backwards-compatibility shim declaring the ES2022 `.at()` methods, and its own note points users at the `es2022` TypeScript lib. `tsconfig.json` `lib` raised to `es2022`; `target` stays `es2021`, so emitted output is unchanged. |
| `avl` → v2 | v2 removed the default export; the min/max aggregators now use `import { AVLTree } from 'avl'`. |
| `webpack-cli` → v7 | No source changes needed. |
| `shaclc-parse` → v2 | Resolution bump. The SHACL compact-syntax system test exercises the parser and passes. |
| `n3` → v2 | N3.js 2 pre-assigns the default graph the lowest internal entity id, so a store iterates the default graph before any named graph. One order-sensitive assertion in the streaming RDF/JS query source tests was reordered; the set of returned bindings is unchanged. |
| `actions/checkout` → v7 | Workflow update. |

## Not applied

**`@types/readable-stream` → 4.0.24 (#160)** — declares `typeScriptVersion: 5.6`; on this repo's TypeScript (lockfile pins 5.3.2 despite `^5.0.0`) it fails to compile with `TS1170`. Moving to TypeScript ≥ 5.6 surfaces its stricter built-in iterator types, which produce 5 errors in `@comunica/types`' nested `lru-cache@10` declaration file. Since `skipLibCheck` is off, clearing that needs either enabling `skipLibCheck` or overriding that transitive dependency — both policy calls rather than part of a types bump. Two additional errors it surfaces in repo code (`SampleAggregator.ts`, `ActorQueryOperationSlice.ts`) are trivially fixable with non-null assertions.

**Jest monorepo → v30** — all 1044 tests pass, but Jest 30 bundles `istanbul-lib-instrument` v6, which counts the implicit `else` of an `if` that has no `else` clause (Jest 29 recorded only one counter). That drops branch coverage to 98.65% against the repo's 100% threshold, exposing 21 never-exercised implicit-else paths across 12 packages. Several sit in red-black tree rebalancing and GraphQL streaming internals, and the module-scope `if (is_node())` in `ActorSourceWatchSolidNotificationWebsockets` can never take its else path in a Node-only test run.

**`componentsjs` → 6.4.0** — the engine config fails to compile: `unknown parameter type`, with `mediatorExpressionEvaluatorFactory` resolving to `undefined` for `ActorQueryOperationLeftJoin`. The affected actor definition comes from Comunica's own shipped `leftjoin.json`. Bisected: 6.2.1 and 6.3.0 compile fine, 6.4.0 does not.

**Comunica monorepo → v5** — an engine-level API migration rather than a version bump: 78 type errors across 32 files. `sparqlalgebrajs`' algebra is replaced by `@comunica/utils-algebra` (`Operation` → `BaseOperation`, `Expression` → `BaseExpression`, `Factory` → `AlgebraFactory`, `types.JOIN` → `Types | TypesComunica`), duplicate `asynciterator` copies conflict nominally, 9 errors land in `@traqula/core`'s declaration files, and `actor-context-preprocess-query-source-identify` / `-skolemize` have no v5 release although the engine config wires both explicitly.

**`npm-check-updates` → v23** — ESM-only, skipped as agreed.

**`typescript` → v7** — out of scope for this pass.

**`lru-cache` → v11** — Renovate lists it as blocked by closed PR #122, so it was treated as previously declined.

## Remaining workflow updates

Four `.github/workflows/CI.yml` updates are prepared but could not be pushed — the token for this session lacks the `workflow` OAuth scope (`actions/checkout` v7 got through before the restriction applied). They are one-line substitutions:

```
actions/setup-node@v3                      -> @v7
actions/cache@v4                           -> @v6
nick-fields/retry@v3                       -> @v4
JamesIves/github-pages-deploy-action@v4.4.0 -> @v4.9.0
```

Every input currently used (`node-version`, `path`/`key`, `timeout_minutes`/`max_attempts`/`command`, `branch`/`folder`/`clean`) is unchanged across those majors.

## Verification

`yarn install` (build + components), `yarn lint-no-cache`, `yarn depcheck`, and `yarn test` all pass on the final branch: 64 suites, 1044 tests, coverage thresholds met. Browser tests were not used as a gate here — this sandbox's headless browser cannot reach the network, so the "with external network" cases fail independently of these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DDEiRjFYicEGLR8mnQi6Lq

---
_Generated by [Claude Code](https://claude.ai/code/session_01DDEiRjFYicEGLR8mnQi6Lq)_